### PR TITLE
Update controller-gen tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v3.8.7
-CONTROLLER_TOOLS_VERSION ?= v0.10.0
+CONTROLLER_TOOLS_VERSION ?= v0.15.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize


### PR DESCRIPTION
The most recent tutorial (found here: https://www.redhat.com/en/blog/red-hat-openshift-operators-concept-and-working-example-golang) has segfaults using go 1.22.5 on OSX (23.3.0 Darwin Kernel). 
Moving to the latest version fixes the issue and make the tutorial possible